### PR TITLE
Fix/http loader

### DIFF
--- a/cmd/data_validate/main.go
+++ b/cmd/data_validate/main.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/bmeg/golib"
 	"github.com/santhosh-tekuri/jsonschema/v5"
+	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
+
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )

--- a/cmd/schema_graph/main.go
+++ b/cmd/schema_graph/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bmeg/sifter/schema"
 	"github.com/santhosh-tekuri/jsonschema/v5"
+	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220311224846-910ce60578df
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/minio/minio-go/v7 v7.0.52
-	github.com/santhosh-tekuri/jsonschema/v5 v5.1.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.4.0
 	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220311224846-910ce60578df
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/minio/minio-go/v7 v7.0.52
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.1.1
 	github.com/spf13/cobra v1.4.0
 	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.3.0
@@ -105,3 +105,5 @@ require (
 	k8s.io/apimachinery v0.20.6 // indirect
 	vitess.io/vitess v0.15.2 // indirect
 )
+
+replace github.com/santhosh-tekuri/jsonschema/v5 v5.1.1 => github.com/bmeg/jsonschema/v5 v5.3.3

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/bmeg/grip v0.0.0-20210910231938-94d69d94ff65 h1:ngj395aMDI4GZaN77fwjt
 github.com/bmeg/grip v0.0.0-20210910231938-94d69d94ff65/go.mod h1:wBLwQsr53I/0kdS4LYL7R4tMshZCVerCWnPTwMdKX3s=
 github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad h1:ICgBexeLB7iv/IQz4rsP+MimOXFZUwWSPojEypuOaQ8=
 github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad/go.mod h1:ft96Irkp72C7ZrUWRenG7LrF0NKMxXdRvsypo5Njhm4=
+github.com/bmeg/jsonschema/v5 v5.3.3 h1:D6grCYWVSOME02gkaG5t51X+ytq+WlmaRTat6rh0OU4=
+github.com/bmeg/jsonschema/v5 v5.3.3/go.mod h1:W6ZrtycDFIco8t+VZvgCgt2mUb+o8Js25o6g+Pe/CHU=
 github.com/bmeg/protoc-gen-grcp-rest-direct v0.0.0-20190228222353-4d40e8b9d305/go.mod h1:1S3ijn0o+w7RmSdfX3EQttlrF9csSziK8dpeh0nP4LU=
 github.com/bmeg/sifter v0.0.0-20230424184727-f9af6ef30a1e h1:yp8fPC1qWARmg9qtpQoE9cqL9J0UMlSA8IG8zXggKAk=
 github.com/bmeg/sifter v0.0.0-20230424184727-f9af6ef30a1e/go.mod h1:AF/K4giHgn6ygrEwH4JwicvIG4cnnQdV5H/nCe4mXtA=
@@ -676,8 +678,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d/go.mod h1:w5+eXa0mYznDkHaMCXA4XYffjlH+cy1oyKbfzJXa2Do=

--- a/go.sum
+++ b/go.sum
@@ -676,8 +676,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/santhosh-tekuri/jsonschema/v5 v5.1.1 h1:lEOLY2vyGIqKWUI9nzsOJRV3mb3WC9dXYORsLEUcoeY=
-github.com/santhosh-tekuri/jsonschema/v5 v5.1.1/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d/go.mod h1:w5+eXa0mYznDkHaMCXA4XYffjlH+cy1oyKbfzJXa2Do=


### PR DESCRIPTION
This PR:
* improves schema parsing by specifying a loader for $ref with http(s):// scheme
* improves schema parsing by using our fork of jsonschema repository which was missing support for "https://json-schema.org/draft/2020-12/hyper-schema"