### PR TITLE
Manifest Tools

### DIFF
--- a/manifest/loader.go
+++ b/manifest/loader.go
@@ -11,6 +11,12 @@ type ScriptRecord struct {
 	Files []FileRecord `json:"files"`
 }
 
+type SummaryRecord struct {
+	FileCount int    `json:"fileCount"`
+	TotalSize uint64 `json:"totalSize"`
+}
+
 type Manifest struct {
+	Summary SummaryRecord  `json:"summary"`
 	Sources []ScriptRecord `json:"sources"`
 }


### PR DESCRIPTION
Tools and methods to generating and using manifest files. Manifest files are meant to track all data files that are required for a build. The idea would be to scan build scripts of a project, identify all files that declare as inputs, and then ensure that are accounted for. Additionally, a manifest could be used to checkin/checkout to a large object storage system